### PR TITLE
The dafult port for dashboard in updated version changed to 8080

### DIFF
--- a/docs/QuickStart.html
+++ b/docs/QuickStart.html
@@ -198,7 +198,7 @@
 </div>
 <div class="section" id="view-the-results">
 <h2><span class="section-number">3.1.3. </span>View the results<a class="headerlink" href="#view-the-results" title="Permalink to this headline">¶</a></h2>
-<p>Go to http://127.0.0.1:8200/dashboard to see the results. The default port is 8200, and you can change the default settings in the <a class="reference external" href="Configs.html#runtime-config">Configs</a>.</p>
+<p>Go to http://127.0.0.1:8080/dashboard to see the results. The default port is 8080, and you can change the default settings in the <a class="reference external" href="Configs.html#runtime-config">Configs</a>.</p>
 <p>Here’s an example of the <a class="reference external" href="#dashboard-example">dashboard</a>.</p>
 </div>
 <div class="section" id="stop-the-experiment">


### PR DESCRIPTION
Hi Dai,
It seems you have changed the default port for quick start runtime_config from 8200 to 8080.
This is just an update in the document.